### PR TITLE
Add database seed data and make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ help:
 	@echo "  make migrate           - Run all pending migrations"
 	@echo "  make migrate-revert    - Revert the latest migration"
 	@echo "  make prepare           - Generate SQLx metadata for offline development"
+	@echo "  make db-seed           - Seed database with initial data"
 	@echo ""
 	@echo "Web Commands:"
 	@echo "  make setup-web         - Set up Web project"
@@ -78,6 +79,7 @@ setup: setup-api setup-node
 
 .PHONY: setup-api
 setup-api: db-create migrate prepare
+	@echo "Run 'make db-seed' if you want to populate the database with sample data"
 
 .PHONY: setup-node
 setup-node:
@@ -297,3 +299,8 @@ migrate-revert:
 prepare:
 	@echo "Preparing SQLx metadata..."
 	@cd $(API_DIR) && DATABASE_URL=$(DATABASE_URL) cargo sqlx prepare
+
+.PHONY: db-seed
+db-seed:
+	@echo "Seeding database with initial data..."
+	@$(API_DIR)/seeds/run_seed.sh

--- a/packages/api/seeds/run_seed.sh
+++ b/packages/api/seeds/run_seed.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Database connection details from environment or defaults
+DB_HOST=${DB_HOST:-localhost}
+DB_PORT=${DB_PORT:-5432}
+DB_NAME=${DB_NAME:-mikinovation}
+DB_USER=${DB_USER:-postgres}
+DB_PASS=${DB_PASS:-postgres}
+
+echo "Running seed script for database $DB_NAME on $DB_HOST:$DB_PORT"
+
+# Run the seed SQL file
+PGPASSWORD=$DB_PASS psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d $DB_NAME -f "$(dirname "$0")/seed.sql"
+
+if [ $? -eq 0 ]; then
+  echo "Seed data imported successfully!"
+else
+  echo "Error importing seed data"
+  exit 1
+fi

--- a/packages/api/seeds/seed.sql
+++ b/packages/api/seeds/seed.sql
@@ -1,0 +1,18 @@
+-- Clean up existing data
+TRUNCATE TABLE todo;
+TRUNCATE TABLE repository;
+
+-- Seed data for todos
+INSERT INTO todo (id, title, completed, created_at, updated_at) VALUES
+('00000000-0000-4000-a000-000000000001', 'Build the frontend', true, NOW(), NOW()),
+('00000000-0000-4000-a000-000000000002', 'Create API endpoints', true, NOW(), NOW()),
+('00000000-0000-4000-a000-000000000003', 'Design database schema', true, NOW(), NOW()),
+('00000000-0000-4000-a000-000000000004', 'Implement authentication', false, NOW(), NOW()),
+('00000000-0000-4000-a000-000000000005', 'Write documentation', false, NOW(), NOW());
+
+-- Seed data for repositories
+INSERT INTO repository (id, github_id, name, full_name, description, language, html_url, stargazers_count, connected_at, created_at, updated_at) VALUES
+('00000000-0000-4000-b000-000000000001', 123456789, 'mikinovation', 'mikinovation/mikinovation', 'Personal portfolio and projects', 'TypeScript', 'https://github.com/mikinovation/mikinovation', 25, NOW(), NOW(), NOW()),
+('00000000-0000-4000-b000-000000000002', 234567890, 'rust-api-example', 'mikinovation/rust-api-example', 'Example Rust API using Axum and SQLx', 'Rust', 'https://github.com/mikinovation/rust-api-example', 42, NOW(), NOW(), NOW()),
+('00000000-0000-4000-b000-000000000003', 345678901, 'vue-ts-starter', 'mikinovation/vue-ts-starter', 'Vue.js TypeScript starter template', 'Vue', 'https://github.com/mikinovation/vue-ts-starter', 18, NOW(), NOW(), NOW()),
+('00000000-0000-4000-b000-000000000004', 456789012, 'docker-compose-setup', 'mikinovation/docker-compose-setup', 'Docker Compose configuration for development', 'Dockerfile', 'https://github.com/mikinovation/docker-compose-setup', 10, NOW(), NOW(), NOW());


### PR DESCRIPTION
## Summary
- Add SQL seed data for Todo and Repository tables
- Create run_seed.sh script for executing seed data
- Add db-seed make command for easy seeding
- Update help message in Makefile

## Test plan
1. Run 'make db-seed' to verify seed data is correctly inserted
2. Verify database tables have the expected data
3. Ensure the added make command works properly