### PR TITLE
chore: update renovate configuration for individual dependency updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,19 @@
-## Linked issue
-<!-- Reference any related issues using the format #123 -->
+### 🔗 Linked issue
 
-## Description
-<!-- Provide a detailed description of the changes included in this PR -->
+<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
+
+### 📚 Description
+
+<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
+
+<!----------------------------------------------------------------------
+Before creating the pull request, please make sure you do the following:
+
+- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
+- Read the contribution docs at https://nuxt.com/docs/community/contribution
+- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
+- Update the corresponding documentation if needed.
+- Include relevant tests that fail without this PR but pass with it.
+
+Thank you for contributing to Nuxt!
+----------------------------------------------------------------------->

--- a/renovate.json
+++ b/renovate.json
@@ -2,82 +2,45 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":dependencyDashboard",
     ":semanticCommits",
-    ":automergeMinor"
   ],
   "labels": [
     "dependencies"
   ],
   "schedule": [
-    "every weekend"
+    "every day"
   ],
-  "prHourlyLimit": 5,
-  "prConcurrentLimit": 10,
   "rangeStrategy": "pin",
   "packageRules": [
     {
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
-    },
-    {
-      "description": "Group all non-major Rust dependencies",
+      "description": "Add rust label to Rust package updates",
       "matchManagers": [
         "cargo"
       ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "Rust dependencies (non-major)",
-      "groupSlug": "rust-minor-patch",
       "addLabels": [
         "rust"
       ]
     },
     {
-      "description": "Group all non-major JavaScript dependencies",
+      "description": "Add javascript label to JavaScript package updates",
       "matchManagers": [
         "npm"
       ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "JavaScript dependencies (non-major)",
-      "groupSlug": "js-minor-patch",
       "addLabels": [
         "javascript"
       ]
     },
     {
-      "description": "Group all DevDependencies",
-      "matchDepTypes": [
-        "devDependencies"
+      "description": "Group TypeScript type definitions with their packages",
+      "matchPackagePatterns": [
+        "^@types/"
       ],
-      "groupName": "DevDependencies",
-      "prPriority": 5
-    },
-    {
-      "description": "Group GitHub Actions",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "groupName": "GitHub Actions",
-      "addLabels": [
-        "github-actions"
-      ]
-    },
-    {
-      "description": "Group Axum ecosystem packages",
-      "groupName": "Axum ecosystem",
-      "matchPackageNames": [
-        "/^axum/",
-        "/tower-http/"
+      "matchPackageNames": [],
+      "groupName": null,
+      "groupSlug": null,
+      "packagePatternGroups": [
+        "^@types/(.*)",
+        "^$1$"
       ]
     }
   ],


### PR DESCRIPTION
## Linked issue
#79 

## Description
This PR updates the renovate.json configuration to:

- Process each library update separately rather than in groups
- Change the schedule from weekends-only to daily updates
- Configure TypeScript type definitions to be updated with their corresponding packages

These changes will provide more granular control over dependency updates while ensuring type safety for TypeScript projects.