### PR TITLE
fix: update renovate schedule to run before 5am

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "dependencies"
   ],
   "schedule": [
-    "every day"
+    "before 5am"
   ],
   "rangeStrategy": "pin",
   "packageRules": [


### PR DESCRIPTION
### 🔗 Linked issue

resolves #84

### 📚 Description

This PR updates the Renovate configuration to change the schedule from 'every day' to 'before 5am'. This helps reduce the frequency of dependency update PRs and ensures they happen during off-hours to minimize disruption.