### PR TITLE
fix: remove TypeScript type definitions grouping in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,19 +30,6 @@
         "javascript"
       ]
     },
-    {
-      "description": "Group TypeScript type definitions with their packages",
-      "matchPackagePatterns": [
-        "^@types/"
-      ],
-      "matchPackageNames": [],
-      "groupName": null,
-      "groupSlug": null,
-      "packagePatternGroups": [
-        "^@types/(.*)",
-        "^$1$"
-      ]
-    }
   ],
   "ignoreDeps": [],
   "ignorePaths": [


### PR DESCRIPTION
### 🔗 Linked issue

resolves #88

### 📚 Description

This PR removes the TypeScript type definitions grouping configuration from renovate.json. This change simplifies the Renovate configuration and allows TypeScript type definitions to be updated independently, which can help prevent potential issues with type mismatches.