### PR TITLE
test: add comprehensive tests for remaining todo handler functions

### DIFF
--- a/packages/api/src/handlers/todo.rs
+++ b/packages/api/src/handlers/todo.rs
@@ -176,6 +176,35 @@ mod tests {
             .expect("Failed to clean up todo table");
     }
 
+    // Helper function to create a test todo
+    async fn create_test_todo(pool: &PgPool, title: &str) -> Todo {
+        let now = Utc::now();
+        let todo = Todo::new(
+            Uuid::new_v4().to_string(),
+            title.to_string(),
+            false,
+            now,
+            now,
+        );
+
+        sqlx::query!(
+            r#"
+            INSERT INTO todo (id, title, completed, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5)
+            "#,
+            todo.id,
+            todo.title,
+            todo.completed,
+            todo.created_at,
+            todo.updated_at
+        )
+        .execute(pool)
+        .await
+        .expect("Failed to create test todo");
+
+        todo
+    }
+
     #[tokio::test]
     async fn test_get_todos_empty() {
         let pool = setup_test_db().await;
@@ -321,5 +350,280 @@ mod tests {
         assert_eq!(todos.len(), 2);
         assert_eq!(todos[0].title, "Newer todo");
         assert_eq!(todos[1].title, "Older todo");
+    }
+
+    #[tokio::test]
+    async fn test_get_todo_success() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        // Create a test todo
+        let test_todo = create_test_todo(&pool, "Test Todo").await;
+
+        // Get the todo
+        let state = State(pool.clone());
+        let path = Path(test_todo.id.clone());
+        let result = get_todo(state, path).await;
+
+        assert!(result.is_ok());
+        let Json(todo) = result.unwrap();
+        assert_eq!(todo.id, test_todo.id);
+        assert_eq!(todo.title, "Test Todo");
+        assert_eq!(todo.completed, false);
+    }
+
+    #[tokio::test]
+    async fn test_get_todo_not_found() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        // Try to get a non-existent todo
+        let state = State(pool.clone());
+        let path = Path(Uuid::new_v4().to_string());
+        let result = get_todo(state, path).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ApiError::NotFound => (),
+            _ => panic!("Expected NotFound error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_todo_success() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        let state = State(pool.clone());
+        let payload = CreateTodo {
+            title: "New Todo".to_string(),
+        };
+        let result = create_todo(state, Json(payload)).await;
+
+        assert!(result.is_ok());
+        let (status, Json(todo)) = result.unwrap();
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(todo.title, "New Todo");
+        assert_eq!(todo.completed, false);
+        assert!(!todo.id.is_empty());
+
+        // Verify it was actually created in the database
+        let saved_todo = sqlx::query_as!(
+            Todo,
+            r#"
+            SELECT id, title, completed, created_at, updated_at
+            FROM todo
+            WHERE id = $1
+            "#,
+            todo.id
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("Failed to fetch created todo");
+
+        assert_eq!(saved_todo.title, "New Todo");
+    }
+
+    #[tokio::test]
+    async fn test_create_todo_empty_title() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        let state = State(pool.clone());
+        let payload = CreateTodo {
+            title: "".to_string(),
+        };
+        let result = create_todo(state, Json(payload)).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ApiError::BadRequest(msg) => assert_eq!(msg, "Title cannot be empty"),
+            _ => panic!("Expected BadRequest error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_todo_whitespace_title() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        let state = State(pool.clone());
+        let payload = CreateTodo {
+            title: "   ".to_string(),
+        };
+        let result = create_todo(state, Json(payload)).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ApiError::BadRequest(msg) => assert_eq!(msg, "Title cannot be empty"),
+            _ => panic!("Expected BadRequest error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_todo_title_only() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        // Create a test todo
+        let test_todo = create_test_todo(&pool, "Original Title").await;
+        let original_updated_at = test_todo.updated_at;
+
+        // Wait a bit to ensure updated_at will be different
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        let state = State(pool.clone());
+        let path = Path(test_todo.id.clone());
+        let payload = UpdateTodo {
+            title: Some("Updated Title".to_string()),
+            completed: None,
+        };
+        let result = update_todo(state, path, Json(payload)).await;
+
+        assert!(result.is_ok());
+        let Json(updated_todo) = result.unwrap();
+        assert_eq!(updated_todo.id, test_todo.id);
+        assert_eq!(updated_todo.title, "Updated Title");
+        assert_eq!(updated_todo.completed, false);
+        assert!(updated_todo.updated_at > original_updated_at);
+    }
+
+    #[tokio::test]
+    async fn test_update_todo_completed_only() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        // Create a test todo
+        let test_todo = create_test_todo(&pool, "Test Todo").await;
+
+        let state = State(pool.clone());
+        let path = Path(test_todo.id.clone());
+        let payload = UpdateTodo {
+            title: None,
+            completed: Some(true),
+        };
+        let result = update_todo(state, path, Json(payload)).await;
+
+        assert!(result.is_ok());
+        let Json(updated_todo) = result.unwrap();
+        assert_eq!(updated_todo.id, test_todo.id);
+        assert_eq!(updated_todo.title, "Test Todo");
+        assert_eq!(updated_todo.completed, true);
+    }
+
+    #[tokio::test]
+    async fn test_update_todo_both_fields() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        // Create a test todo
+        let test_todo = create_test_todo(&pool, "Original Title").await;
+
+        let state = State(pool.clone());
+        let path = Path(test_todo.id.clone());
+        let payload = UpdateTodo {
+            title: Some("New Title".to_string()),
+            completed: Some(true),
+        };
+        let result = update_todo(state, path, Json(payload)).await;
+
+        assert!(result.is_ok());
+        let Json(updated_todo) = result.unwrap();
+        assert_eq!(updated_todo.id, test_todo.id);
+        assert_eq!(updated_todo.title, "New Title");
+        assert_eq!(updated_todo.completed, true);
+    }
+
+    #[tokio::test]
+    async fn test_update_todo_not_found() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        let state = State(pool.clone());
+        let path = Path(Uuid::new_v4().to_string());
+        let payload = UpdateTodo {
+            title: Some("Updated".to_string()),
+            completed: None,
+        };
+        let result = update_todo(state, path, Json(payload)).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ApiError::NotFound => (),
+            _ => panic!("Expected NotFound error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_todo_success() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        // Create a test todo
+        let test_todo = create_test_todo(&pool, "To Be Deleted").await;
+
+        let state = State(pool.clone());
+        let path = Path(test_todo.id.clone());
+        let result = delete_todo(state, path).await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), StatusCode::NO_CONTENT);
+
+        // Verify the todo was actually deleted
+        let deleted_todo = sqlx::query_as!(
+            Todo,
+            r#"
+            SELECT id, title, completed, created_at, updated_at
+            FROM todo
+            WHERE id = $1
+            "#,
+            test_todo.id
+        )
+        .fetch_optional(&pool)
+        .await
+        .expect("Failed to query deleted todo");
+
+        assert!(deleted_todo.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_todo_not_found() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        let state = State(pool.clone());
+        let path = Path(Uuid::new_v4().to_string());
+        let result = delete_todo(state, path).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ApiError::NotFound => (),
+            _ => panic!("Expected NotFound error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_todo_idempotent() {
+        let pool = setup_test_db().await;
+        cleanup_todos(&pool).await;
+
+        // Create and delete a todo
+        let test_todo = create_test_todo(&pool, "To Be Deleted").await;
+        let state = State(pool.clone());
+        let path = Path(test_todo.id.clone());
+
+        // First deletion should succeed
+        let result = delete_todo(state, path).await;
+        assert!(result.is_ok());
+
+        // Second deletion should return NotFound
+        let state2 = State(pool.clone());
+        let path2 = Path(test_todo.id.clone());
+        let result2 = delete_todo(state2, path2).await;
+        assert!(result2.is_err());
+        match result2.unwrap_err() {
+            ApiError::NotFound => (),
+            _ => panic!("Expected NotFound error"),
+        }
     }
 }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #130

### 📚 Description

This PR adds comprehensive unit tests for the remaining todo handler functions that previously lacked test coverage.

**Changes made:**

1. **Added helper function:**
   - `create_test_todo`: Simplifies test setup by creating a todo in the database

2. **Added tests for `get_todo` handler:**
   - `test_get_todo_success`: Verifies successful retrieval of an existing todo
   - `test_get_todo_not_found`: Verifies 404 error when todo doesn't exist

3. **Added tests for `create_todo` handler:**
   - `test_create_todo_success`: Verifies successful todo creation with 201 status code
   - `test_create_todo_empty_title`: Verifies validation error for empty title
   - `test_create_todo_whitespace_title`: Verifies validation error for whitespace-only title

4. **Added tests for `update_todo` handler:**
   - `test_update_todo_title_only`: Verifies partial update of title field
   - `test_update_todo_completed_only`: Verifies partial update of completed field
   - `test_update_todo_both_fields`: Verifies update of both fields
   - `test_update_todo_not_found`: Verifies 404 error when todo doesn't exist
   - Tests also verify that `updated_at` timestamp is properly updated

5. **Added tests for `delete_todo` handler:**
   - `test_delete_todo_success`: Verifies successful deletion with 204 status code
   - `test_delete_todo_not_found`: Verifies 404 error when todo doesn't exist
   - `test_delete_todo_idempotent`: Verifies idempotent behavior (second deletion returns 404)

**Test coverage:**
- All handler functions now have comprehensive test coverage
- Tests cover both success and error cases
- Database state changes are verified
- Proper error types and status codes are validated
- Tests run in isolation using test database cleanup

This completes the test coverage for all todo handler functions, ensuring the API's reliability and making it easier to catch regressions in future changes.