### PR TITLE
chore: update Node.js to 24.2.0 and pnpm to 10.12.1 in web CI workflow

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/web-ci.yml'
 
 env:
-  NODE_VERSION: 24.1.0
+  NODE_VERSION: 24.2.0
   WORKING_DIRECTORY: ./packages/web
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.11.0
+          version: 10.12.1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #174

### 📚 Description

This PR updates the Node.js and pnpm versions in the web CI workflow to their latest versions:

- **Node.js**: Updated from 24.1.0 to 24.2.0
- **pnpm**: Updated from 10.11.0 to 10.12.1

These updates ensure we're using the latest stable versions with security patches, performance improvements, and bug fixes. The changes are made in `.github/workflows/web-ci.yml`.

The workflow should continue to function correctly with these updated versions while benefiting from the latest improvements.