### PR TITLE
feat: configure GitHub Pages deployment for wiki

### DIFF
--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -1,0 +1,65 @@
+name: Deploy Wiki to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'wiki/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.7.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: ./wiki
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Build
+        run: pnpm run generate
+        working-directory: ./wiki
+        env:
+          NUXT_APP_BASE_URL: /mikinovation/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./wiki/.output/public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/wiki/nuxt.config.ts
+++ b/wiki/nuxt.config.ts
@@ -13,5 +13,15 @@ export default defineNuxtConfig({
   css: ['@/assets/css/main.css'],
   content: {
     experimental: { nativeSqlite: true }
+  },
+  app: {
+    baseURL: process.env.NODE_ENV === 'production' ? '/mikinovation/' : '/',
+    buildAssetsDir: 'assets'
+  },
+  nitro: {
+    prerender: {
+      crawlLinks: true,
+      routes: ['/']
+    }
   }
 })

--- a/wiki/package.json
+++ b/wiki/package.json
@@ -7,7 +7,8 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "deploy": "npm run generate"
   },
   "dependencies": {
     "@nuxt/content": "3.8.0",


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated deployment to GitHub Pages
- Configure Nuxt for GitHub Pages with proper baseURL
- Enable static site generation with prerendering

## Changes
- Created `.github/workflows/deploy-wiki.yml` for automated deployment
- Updated `wiki/nuxt.config.ts` with GitHub Pages configuration
- Added deploy script to `wiki/package.json`

## Test Plan
1. Merge this PR to main branch
2. Configure GitHub Pages settings (Settings → Pages → Source: GitHub Actions)
3. Verify deployment at https://mikinovation.github.io/mikinovation/