### PR TITLE
fix: specify pnpm lock file path for cache

### DIFF
--- a/.github/workflows/deploy-wiki.yml
+++ b/.github/workflows/deploy-wiki.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
+          cache-dependency-path: './wiki/pnpm-lock.yaml'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Fixes the GitHub Pages deployment workflow by specifying the correct pnpm lock file path for caching

## Changes
- Updated the pnpm cache setup in the GitHub Actions workflow to use `wiki/pnpm-lock.yaml` instead of the default lock file path
- This ensures proper caching behavior for the wiki deployment process

## Test plan
- [x] Verify GitHub Actions workflow runs successfully
- [x] Confirm pnpm cache is properly utilized during deployment
- [x] Check that wiki deploys correctly to GitHub Pages