### PR TITLE
feat: add label support to wiki articles with filtering functionality

### DIFF
--- a/wiki/app/components/wiki/PageCard.vue
+++ b/wiki/app/components/wiki/PageCard.vue
@@ -5,6 +5,7 @@ type Props = {
     title: string
     description: string
     date: string | Date
+    labels: string[]
   }
 }
 
@@ -31,6 +32,16 @@ const formatDateISO = (date: string | Date) => {
 
     <h2 class="text-xl font-bold mb-2 text-gray-900">{{ page.title }}</h2>
     <p class="text-gray-600 mb-4 line-clamp-2">{{ page.description }}</p>
+
+    <div class="flex flex-wrap gap-2 mb-4">
+      <span
+        v-for="label in page.labels"
+        :key="label"
+        class="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full"
+      >
+        {{ label }}
+      </span>
+    </div>
 
     <div class="text-sm text-gray-500">
       <time :datetime="formatDateISO(page.date)">{{ formatDate(page.date) }}</time>

--- a/wiki/app/components/wiki/PageList.vue
+++ b/wiki/app/components/wiki/PageList.vue
@@ -5,6 +5,7 @@ type Props = {
     title: string
     description: string
     date: string | Date
+    labels: string[]
   }>
 }
 

--- a/wiki/app/pages/wiki/index.vue
+++ b/wiki/app/pages/wiki/index.vue
@@ -4,6 +4,29 @@ const { data: pages } = await useAsyncData('pages', () =>
     .all()
 )
 
+const selectedLabel = ref<string | null>(null)
+
+const allLabels = computed(() => {
+  if (!pages.value) return []
+  const labelSet = new Set<string>()
+  pages.value.forEach(page => {
+    page.labels?.forEach((label: string) => labelSet.add(label))
+  })
+  return Array.from(labelSet).sort()
+})
+
+const filteredPages = computed(() => {
+  if (!pages.value) return []
+  if (!selectedLabel.value) return pages.value
+  return pages.value.filter(page =>
+    page.labels?.includes(selectedLabel.value!)
+  )
+})
+
+const filterByLabel = (label: string | null) => {
+  selectedLabel.value = label
+}
+
 useSeoMeta({
   title: 'Wiki - mikinovation',
   description: 'ナレッジベース。技術的なドキュメントやメモを整理しています。',
@@ -69,7 +92,38 @@ useSeoMeta({
     <!-- Page List Section -->
     <div class="max-w-4xl mx-auto">
       <h2 class="text-2xl font-semibold mb-6 text-gray-800">記事一覧</h2>
-      <WikiPageList v-if="pages" :pages="pages" />
+
+      <!-- Label Filter -->
+      <div v-if="allLabels.length > 0" class="mb-6">
+        <div class="flex flex-wrap gap-2">
+          <button
+            :class="[
+              'px-4 py-2 text-sm font-medium rounded-full transition-colors',
+              selectedLabel === null
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+            ]"
+            @click="filterByLabel(null)"
+          >
+            すべて
+          </button>
+          <button
+            v-for="label in allLabels"
+            :key="label"
+            :class="[
+              'px-4 py-2 text-sm font-medium rounded-full transition-colors',
+              selectedLabel === label
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+            ]"
+            @click="filterByLabel(label)"
+          >
+            {{ label }}
+          </button>
+        </div>
+      </div>
+
+      <WikiPageList v-if="filteredPages.length > 0" :pages="filteredPages" />
       <div v-else class="text-center text-gray-500 py-8">
         ページがありません
       </div>

--- a/wiki/content.config.ts
+++ b/wiki/content.config.ts
@@ -9,6 +9,7 @@ export const collections = {
       description: z.string(),
       date: z.string().or(z.date()),
       draft: z.boolean().optional().default(false),
+      labels: z.array(z.string()),
     })
   })
 }

--- a/wiki/content/wiki/first-post.md
+++ b/wiki/content/wiki/first-post.md
@@ -3,6 +3,11 @@ title: 'Nixの設定'
 description: 'Nix FlakesとHome Managerを使用した開発環境の宣言的構成管理。モジュール化された設定とクロスプラットフォーム対応について解説します。'
 date: '2025-01-03'
 draft: false
+labels:
+  - Nix
+  - DevOps
+  - Configuration
+  - Development Environment
 ---
 
 # Nix 設定ドキュメント

--- a/wiki/content/wiki/second-post.md
+++ b/wiki/content/wiki/second-post.md
@@ -3,6 +3,11 @@ title: 'TypeScript で型安全な開発を実現する'
 description: 'TypeScript を使った型安全な開発手法について。Nuxt 4 での TypeScript 活用例を紹介します。'
 date: '2025-11-02'
 draft: false
+labels:
+  - TypeScript
+  - Nuxt
+  - Web Development
+  - Type Safety
 ---
 
 # TypeScript で型安全な開発を実現する

--- a/wiki/content/wiki/third-post.md
+++ b/wiki/content/wiki/third-post.md
@@ -3,6 +3,12 @@ title: 'Tailwind CSS によるユーティリティファーストデザイン'
 description: 'Tailwind CSS を使った効率的なスタイリング手法。Nuxt UI との組み合わせで、美しいUIを素早く構築する方法を紹介します。'
 date: '2025-11-01'
 draft: false
+labels:
+  - Tailwind CSS
+  - CSS
+  - Web Development
+  - UI/UX
+  - Design System
 ---
 
 # Tailwind CSS によるユーティリティファーストデザイン


### PR DESCRIPTION
## Summary
- Added label support to wiki articles through frontmatter
- Implemented label-based filtering functionality on the wiki index page
- Enhanced PageCard component to display article labels
- Added labels to existing wiki articles (first-post, second-post, third-post)

## Changes
- Modified `wiki/content.config.ts` to include labels field in the schema
- Updated `wiki/app/components/wiki/PageCard.vue` to display labels with styling
- Enhanced `wiki/app/components/wiki/PageList.vue` to pass labels prop
- Implemented filtering UI and logic in `wiki/app/pages/wiki/index.vue`
- Added sample labels to all existing wiki articles

## Test plan
- [x] Verify labels are displayed correctly on wiki article cards
- [x] Test filtering functionality with different label combinations
- [x] Ensure "All" button shows all articles
- [x] Confirm label styling and visual appearance
- [x] Check that labels are properly extracted from frontmatter