### PR TITLE
feat: add related articles feature with bidirectional linking

### DIFF
--- a/wiki/app/components/wiki/RelatedArticles.vue
+++ b/wiki/app/components/wiki/RelatedArticles.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import type { RelatedArticle } from '@/composables/useRelatedArticles'
+
+type Props = {
+  articles: RelatedArticle[]
+}
+
+const props = defineProps<Props>()
+
+const formatDate = (date: string | Date) => {
+  return new Date(date).toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  })
+}
+</script>
+
+<template>
+  <div v-if="props.articles.length > 0" class="mt-12 pt-8 border-t border-gray-200">
+    <h2 class="text-2xl font-bold mb-6 text-gray-800">関連記事</h2>
+    <div class="grid gap-6 md:grid-cols-2">
+      <NuxtLink
+        v-for="article in props.articles"
+        :key="article.slug"
+        :to="article.path"
+        class="block p-6 bg-white rounded-lg border border-gray-200 hover:border-blue-500 hover:shadow-md transition-all"
+      >
+        <h3 class="text-lg font-semibold mb-2 text-gray-900 hover:text-blue-600">
+          {{ article.title }}
+        </h3>
+        <p class="text-sm text-gray-600 mb-3 line-clamp-2">
+          {{ article.description }}
+        </p>
+        <div class="flex items-center justify-between">
+          <time class="text-xs text-gray-500">
+            {{ formatDate(article.date) }}
+          </time>
+          <div class="flex flex-wrap gap-2">
+            <span
+              v-for="label in article.labels.slice(0, 2)"
+              :key="label"
+              class="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded"
+            >
+              {{ label }}
+            </span>
+          </div>
+        </div>
+      </NuxtLink>
+    </div>
+  </div>
+</template>

--- a/wiki/app/composables/useRelatedArticles.ts
+++ b/wiki/app/composables/useRelatedArticles.ts
@@ -1,0 +1,15 @@
+export type RelatedArticle = {
+  title: string
+  description: string
+  slug: string
+  path: string
+  date: string | Date
+  labels: string[]
+}
+
+export const useRelatedArticles = (slug: string) => {
+  return useAsyncData(
+    `related-articles-${slug}`,
+    () => $fetch<RelatedArticle[]>(`/api/wiki/${slug}/related`)
+  )
+}

--- a/wiki/app/pages/wiki/[slug].vue
+++ b/wiki/app/pages/wiki/[slug].vue
@@ -10,6 +10,9 @@ if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found' })
 }
 
+// 関連記事を取得
+const { data: relatedArticles } = await useRelatedArticles(route.params.slug as string)
+
 // SEO メタタグ設定
 useSeoMeta({
   title: page.value.title,
@@ -45,6 +48,9 @@ const formatDateISO = (date: string | Date) => {
 
       <!-- ページ本文 -->
       <WikiPageContent :page="page" />
+
+      <!-- 関連記事 -->
+      <WikiRelatedArticles v-if="relatedArticles" :articles="relatedArticles" />
     </article>
   </div>
 </template>

--- a/wiki/content.config.ts
+++ b/wiki/content.config.ts
@@ -10,6 +10,7 @@ export const collections = {
       date: z.string().or(z.date()),
       draft: z.boolean().optional().default(false),
       labels: z.array(z.string()),
+      relatedArticles: z.array(z.string()),
     })
   })
 }

--- a/wiki/content/wiki/first-post.md
+++ b/wiki/content/wiki/first-post.md
@@ -8,6 +8,8 @@ labels:
   - DevOps
   - Configuration
   - Development Environment
+relatedArticles:
+  - second-post
 ---
 
 # Nix 設定ドキュメント

--- a/wiki/content/wiki/second-post.md
+++ b/wiki/content/wiki/second-post.md
@@ -8,6 +8,8 @@ labels:
   - Nuxt
   - Web Development
   - Type Safety
+relatedArticles:
+  - third-post
 ---
 
 # TypeScript で型安全な開発を実現する

--- a/wiki/content/wiki/third-post.md
+++ b/wiki/content/wiki/third-post.md
@@ -9,6 +9,9 @@ labels:
   - Web Development
   - UI/UX
   - Design System
+relatedArticles:
+  - second-post
+  - first-post
 ---
 
 # Tailwind CSS によるユーティリティファーストデザイン

--- a/wiki/server/api/wiki/[slug]/related.get.ts
+++ b/wiki/server/api/wiki/[slug]/related.get.ts
@@ -1,0 +1,64 @@
+export default defineEventHandler(async (event) => {
+  const slug = getRouterParam(event, 'slug')
+
+  if (!slug) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Slug is required'
+    })
+  }
+
+  // 現在の記事を取得
+  const currentArticle = await queryCollection(event, 'wiki')
+    .path(`/wiki/${slug}`)
+    .first()
+
+  if (!currentArticle) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Article not found'
+    })
+  }
+
+  // すべての記事を取得
+  const allArticles = await queryCollection(event, 'wiki').all()
+
+  // スラッグ抽出用のヘルパー関数
+  const extractSlug = (path: string): string => {
+    const pathParts = path.split('/')
+    return pathParts[pathParts.length - 1]
+  }
+
+  const currentSlug = extractSlug(currentArticle.path)
+
+  // 1. 現在の記事から参照している記事のスラッグ
+  const directRelatedSlugs = currentArticle.relatedArticles || []
+
+  // 2. 現在の記事を参照している記事（逆方向）のスラッグ
+  const reverseRelatedSlugs = allArticles
+    .filter((article) => {
+      const articleRelated = article.relatedArticles || []
+      return articleRelated.includes(currentSlug)
+    })
+    .map((article) => extractSlug(article.path))
+
+  // 3. 双方向の関連記事スラッグを統合（重複排除）
+  const allRelatedSlugs = [...new Set([...directRelatedSlugs, ...reverseRelatedSlugs])]
+
+  // 関連記事の詳細を取得
+  const relatedArticles = allArticles
+    .filter((article) => {
+      const articleSlug = extractSlug(article.path)
+      return allRelatedSlugs.includes(articleSlug)
+    })
+    .map((article) => ({
+      title: article.title,
+      description: article.description,
+      slug: extractSlug(article.path),
+      path: article.path,
+      date: article.date,
+      labels: article.labels || []
+    }))
+
+  return relatedArticles
+})


### PR DESCRIPTION
## Summary
This PR adds a related articles feature to the wiki system with support for bidirectional linking between articles.

### Changes
- **New Component**: `RelatedArticles.vue` - Displays related articles in a responsive grid layout
- **New Composable**: `useRelatedArticles` - Fetches related articles data via API
- **New API Endpoint**: `/api/wiki/[slug]/related` - Returns related articles with bidirectional relation support
- **Schema Update**: Added `relatedArticles` field to content configuration
- **Content Updates**: Added related article metadata to existing wiki posts
- **Integration**: Connected related articles display to wiki detail pages

### Features
- Bidirectional linking: If article A references article B, article B will also show article A as related
- Responsive card layout for related articles
- Display of title, description, date, and labels
- Hover effects and smooth transitions

## Test Plan
- [x] Verify related articles display correctly on wiki detail pages
- [x] Test bidirectional linking between articles
- [x] Check responsive layout on different screen sizes
- [x] Validate API endpoint returns correct related articles
- [x] Ensure no duplicate articles in related section