### PR TITLE
Fix prerender error by adding root page redirect

### DIFF
--- a/wiki/app/pages/index.vue
+++ b/wiki/app/pages/index.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+const config = useRuntimeConfig()
+
+// production環境では /mikinovation/wiki にリダイレクト
+// development環境では /wiki にリダイレクト
+if (import.meta.client) {
+  const targetPath = config.app.baseURL === '/mikinovation/'
+    ? '/mikinovation/wiki'
+    : '/wiki'
+  await navigateTo(targetPath, { replace: true })
+}
+
+// サーバーサイドでもリダイレクト
+if (import.meta.server) {
+  const targetPath = config.app.baseURL === '/mikinovation/'
+    ? '/mikinovation/wiki'
+    : '/wiki'
+  await navigateTo(targetPath, { replace: true })
+}
+</script>
+
+<template>
+  <div class="flex items-center justify-center min-h-screen">
+    <div class="text-center">
+      <p class="text-gray-600">リダイレクト中...</p>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
Resolves the prerender error that was occurring during CI build by adding a root page that redirects to the wiki.

## Problem
The build was failing with the following error:
```
[nitro]   ├─ /mikinovation/ (40ms)
  │ ├── [404] Page not found: /
  │ └── Linked from /wiki

ERROR  Exiting due to prerender errors.
```

The prerenderer was trying to generate `/mikinovation/` but no root page (`/`) existed.

## Solution
- Created `wiki/app/pages/index.vue` to handle the root path
- Added environment-aware redirects:
  - Production: redirects to `/mikinovation/wiki`
  - Development: redirects to `/wiki`
- Implements both client-side and server-side redirects for proper SSR support

## Test Results
Build now completes successfully:
```
[nitro] ℹ Prerendered 13 routes in 3.191 seconds
[nitro] ✔ Generated public .output/public
```