### PR TITLE
feat(wiki): apply retro game-style monochrome design

### DIFF
--- a/wiki/app/assets/css/main.css
+++ b/wiki/app/assets/css/main.css
@@ -1,3 +1,61 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 @import "@nuxt/ui";
+
+:root {
+  --retro-bg: #111111;
+  --retro-bg-card: #222222;
+  --retro-text: #e0e0e0;
+  --retro-text-accent: #cccccc;
+  --retro-border: #888888;
+}
+
+body {
+  font-family: 'DotGothic16', cursive, monospace;
+  background-color: var(--retro-bg);
+  color: var(--retro-text);
+}
+
+/* Prose overrides for retro theme */
+.prose {
+  --tw-prose-body: var(--retro-text);
+  --tw-prose-headings: var(--retro-text);
+  --tw-prose-lead: var(--retro-text);
+  --tw-prose-links: var(--retro-text-accent);
+  --tw-prose-bold: var(--retro-text);
+  --tw-prose-counters: var(--retro-text);
+  --tw-prose-bullets: var(--retro-text);
+  --tw-prose-hr: var(--retro-border);
+  --tw-prose-quotes: var(--retro-text);
+  --tw-prose-quote-borders: var(--retro-border);
+  --tw-prose-captions: var(--retro-text);
+  --tw-prose-code: var(--retro-text);
+  --tw-prose-pre-code: var(--retro-text);
+  --tw-prose-pre-bg: var(--retro-bg-card);
+  --tw-prose-th-borders: var(--retro-border);
+  --tw-prose-td-borders: var(--retro-border);
+}
+
+/* Scrollbar retro style */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--retro-bg);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--retro-text);
+}
+
+/* Retro blink animation for hover */
+@keyframes retro-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.retro-blink:hover {
+  animation: retro-blink 1s step-end infinite;
+}

--- a/wiki/app/components/layout/Footer.vue
+++ b/wiki/app/components/layout/Footer.vue
@@ -3,9 +3,9 @@ const currentYear = new Date().getFullYear()
 </script>
 
 <template>
-  <footer class="bg-gray-50 border-t border-gray-200 mt-12">
+  <footer class="bg-[#111111] border-t-2 border-[#888888] mt-12">
     <div class="container mx-auto px-4 py-8">
-      <div class="text-center text-gray-600">
+      <div class="text-center text-[#e0e0e0]/60">
         <p>&copy; {{ currentYear }} mikinovation. All rights reserved.</p>
       </div>
     </div>

--- a/wiki/app/components/layout/Header.vue
+++ b/wiki/app/components/layout/Header.vue
@@ -2,15 +2,15 @@
 </script>
 
 <template>
-  <header class="bg-white border-b border-gray-200">
+  <header class="bg-[#111111] border-b-2 border-[#888888]">
     <nav class="container mx-auto px-4 py-4">
       <div class="flex items-center justify-between">
-        <NuxtLink to="/" class="text-2xl font-bold text-gray-900">
-          Wiki
+        <NuxtLink to="/" class="text-2xl font-bold text-[#e0e0e0] tracking-wider">
+          &gt; Wiki_
         </NuxtLink>
 
         <div class="flex items-center space-x-6">
-          <NuxtLink to="/" class="text-gray-700 hover:text-gray-900">
+          <NuxtLink to="/" class="text-[#e0e0e0] hover:text-[#888888]">
             Home
           </NuxtLink>
         </div>

--- a/wiki/app/components/mdc/ProsePre.vue
+++ b/wiki/app/components/mdc/ProsePre.vue
@@ -40,7 +40,7 @@ async function renderMermaid() {
     // Initialize mermaid with configuration
     mermaid.initialize({
       startOnLoad: false,
-      theme: 'default',
+      theme: 'dark',
       securityLevel: 'loose',
     })
 
@@ -71,7 +71,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div v-if="isMermaid" class="overflow-x-auto p-4 bg-transparent my-6">
+  <div v-if="isMermaid" class="overflow-x-auto p-4 bg-[#222222] border-2 border-[#888888] my-6">
     <div ref="mermaidContainer" class="flex justify-center items-center min-h-[100px] [&_svg]:max-w-full [&_svg]:h-auto"></div>
   </div>
   <pre v-else :class="props.class" :style="props.style">

--- a/wiki/app/components/wiki/PageCard.vue
+++ b/wiki/app/components/wiki/PageCard.vue
@@ -27,23 +27,23 @@ const formatDateISO = (date: string | Date) => {
 <template>
   <NuxtLink
     :to="page.path"
-    class="block bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow"
+    class="block bg-[#222222] border-2 border-[#888888] p-6 hover:bg-[#111111] transition-colors"
   >
 
-    <h2 class="text-xl font-bold mb-2 text-gray-900">{{ page.title }}</h2>
-    <p class="text-gray-600 mb-4 line-clamp-2">{{ page.description }}</p>
+    <h2 class="text-xl font-bold mb-2 text-[#e0e0e0]">{{ page.title }}</h2>
+    <p class="text-[#e0e0e0]/70 mb-4 line-clamp-2">{{ page.description }}</p>
 
     <div class="flex flex-wrap gap-2 mb-4">
       <span
         v-for="label in page.labels"
         :key="label"
-        class="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full"
+        class="px-2 py-1 text-xs font-medium bg-[#e0e0e0] text-[#111111]"
       >
         {{ label }}
       </span>
     </div>
 
-    <div class="text-sm text-gray-500">
+    <div class="text-sm text-[#e0e0e0]/50">
       <time :datetime="formatDateISO(page.date)">{{ formatDate(page.date) }}</time>
     </div>
   </NuxtLink>

--- a/wiki/app/components/wiki/PageContent.vue
+++ b/wiki/app/components/wiki/PageContent.vue
@@ -9,7 +9,7 @@ defineProps<Props>()
 </script>
 
 <template>
-  <div class="prose prose-lg md:prose-xl max-w-none dark:prose-invert prose-slate prose-headings:font-bold prose-a:text-primary">
+  <div class="prose prose-lg md:prose-xl max-w-none prose-headings:font-bold prose-a:text-[#cccccc] prose-a:underline prose-a:decoration-dotted prose-pre:bg-[#222222] prose-pre:border-2 prose-pre:border-[#888888] prose-pre:rounded-none">
     <ContentRenderer :value="page" />
   </div>
 </template>

--- a/wiki/app/components/wiki/RelatedArticles.vue
+++ b/wiki/app/components/wiki/RelatedArticles.vue
@@ -17,30 +17,30 @@ const formatDate = (date: string | Date) => {
 </script>
 
 <template>
-  <div v-if="props.articles.length > 0" class="mt-12 pt-8 border-t border-gray-200">
-    <h2 class="text-2xl font-bold mb-6 text-gray-800">関連記事</h2>
+  <div v-if="props.articles.length > 0" class="mt-12 pt-8 border-t-2 border-[#888888]">
+    <h2 class="text-2xl font-bold mb-6 text-[#e0e0e0]">関連記事</h2>
     <div class="grid gap-6 md:grid-cols-2">
       <NuxtLink
         v-for="article in props.articles"
         :key="article.slug"
         :to="article.path"
-        class="block p-6 bg-white rounded-lg border border-gray-200 hover:border-blue-500 hover:shadow-md transition-all"
+        class="block p-6 bg-[#222222] border-2 border-[#888888] hover:bg-[#111111] transition-colors"
       >
-        <h3 class="text-lg font-semibold mb-2 text-gray-900 hover:text-blue-600">
+        <h3 class="text-lg font-semibold mb-2 text-[#e0e0e0]">
           {{ article.title }}
         </h3>
-        <p class="text-sm text-gray-600 mb-3 line-clamp-2">
+        <p class="text-sm text-[#e0e0e0]/70 mb-3 line-clamp-2">
           {{ article.description }}
         </p>
         <div class="flex items-center justify-between">
-          <time class="text-xs text-gray-500">
+          <time class="text-xs text-[#e0e0e0]/50">
             {{ formatDate(article.date) }}
           </time>
           <div class="flex flex-wrap gap-2">
             <span
               v-for="label in article.labels.slice(0, 2)"
               :key="label"
-              class="px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded"
+              class="px-2 py-1 text-xs font-medium bg-[#e0e0e0] text-[#111111]"
             >
               {{ label }}
             </span>

--- a/wiki/app/layouts/default.vue
+++ b/wiki/app/layouts/default.vue
@@ -2,7 +2,7 @@
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col">
+  <div class="min-h-screen flex flex-col bg-[#111111] text-[#e0e0e0]">
     <LayoutHeader />
     <main class="flex-grow">
       <slot />

--- a/wiki/app/pages/wiki/[slug].vue
+++ b/wiki/app/pages/wiki/[slug].vue
@@ -41,7 +41,7 @@ const formatDateISO = (date: string | Date) => {
       <!-- メタデータ -->
       <header class="mb-8">
         <h1 class="text-4xl font-bold mb-4">{{ page.title }}</h1>
-        <div class="text-gray-600">
+        <div class="text-[#e0e0e0]/60">
           <time :datetime="formatDateISO(page.date)">{{ formatDate(page.date) }}</time>
         </div>
       </header>

--- a/wiki/app/pages/wiki/index.vue
+++ b/wiki/app/pages/wiki/index.vue
@@ -37,14 +37,14 @@ useSeoMeta({
   <div class="container mx-auto px-4 py-8">
     <div class="text-center mb-12">
       <h1 class="text-4xl font-bold mb-4">Wiki</h1>
-      <p class="text-gray-600">ナレッジベース</p>
+      <p class="text-[#e0e0e0]/70">ナレッジベース</p>
     </div>
 
     <!-- Wiki Purpose and Policy Section -->
-    <div class="max-w-4xl mx-auto mb-12 bg-white rounded-lg shadow-sm p-8">
+    <div class="max-w-4xl mx-auto mb-12 bg-[#222222] border-2 border-[#888888] p-8">
       <section class="mb-8">
-        <h2 class="text-2xl font-semibold mb-4 text-gray-800">このWikiについて</h2>
-        <p class="text-gray-700 leading-relaxed mb-4">
+        <h2 class="text-2xl font-semibold mb-4 text-[#e0e0e0]">このWikiについて</h2>
+        <p class="text-[#e0e0e0]/80 leading-relaxed mb-4">
           このWikiは、技術的な知識やノウハウを体系的に整理・共有するためのナレッジベースです。
           学習した内容、問題解決の過程、ベストプラクティスなどを記録し、
           将来の自分や他の開発者が参照できる形で保存しています。
@@ -52,8 +52,8 @@ useSeoMeta({
       </section>
 
       <section class="mb-8">
-        <h2 class="text-2xl font-semibold mb-4 text-gray-800">目的</h2>
-        <ul class="list-disc list-inside space-y-2 text-gray-700">
+        <h2 class="text-2xl font-semibold mb-4 text-[#e0e0e0]">目的</h2>
+        <ul class="list-disc list-inside space-y-2 text-[#e0e0e0]/80">
           <li>技術的な知識の蓄積と共有</li>
           <li>問題解決のパターンとノウハウの記録</li>
           <li>学習内容の整理と定着</li>
@@ -63,26 +63,26 @@ useSeoMeta({
       </section>
 
       <section>
-        <h2 class="text-2xl font-semibold mb-4 text-gray-800">記載方針</h2>
-        <div class="space-y-3 text-gray-700">
+        <h2 class="text-2xl font-semibold mb-4 text-[#e0e0e0]">記載方針</h2>
+        <div class="space-y-3 text-[#e0e0e0]/80">
           <div>
-            <h3 class="font-semibold mb-1">完成を求めない</h3>
+            <h3 class="font-semibold mb-1 text-[#e0e0e0]">完成を求めない</h3>
             <p class="text-sm">途中段階でも積極的に記録します。完璧を目指すより、まず書き残すことを優先します。</p>
           </div>
           <div>
-            <h3 class="font-semibold mb-1">明確で分かりやすく</h3>
+            <h3 class="font-semibold mb-1 text-[#e0e0e0]">明確で分かりやすく</h3>
             <p class="text-sm">技術的な内容を誰でも理解できるよう、明確で簡潔な説明を心がけます。</p>
           </div>
           <div>
-            <h3 class="font-semibold mb-1">実用的な内容</h3>
+            <h3 class="font-semibold mb-1 text-[#e0e0e0]">実用的な内容</h3>
             <p class="text-sm">実際のプロジェクトや開発で役立つ、実践的な情報を優先します。</p>
           </div>
           <div>
-            <h3 class="font-semibold mb-1">継続的な更新</h3>
+            <h3 class="font-semibold mb-1 text-[#e0e0e0]">継続的な更新</h3>
             <p class="text-sm">技術の進化に合わせて、定期的に内容を見直し更新します。</p>
           </div>
           <div>
-            <h3 class="font-semibold mb-1">体系的な整理</h3>
+            <h3 class="font-semibold mb-1 text-[#e0e0e0]">体系的な整理</h3>
             <p class="text-sm">カテゴリーやタグを活用し、情報を探しやすく整理します。</p>
           </div>
         </div>
@@ -91,17 +91,17 @@ useSeoMeta({
 
     <!-- Page List Section -->
     <div class="max-w-4xl mx-auto">
-      <h2 class="text-2xl font-semibold mb-6 text-gray-800">記事一覧</h2>
+      <h2 class="text-2xl font-semibold mb-6 text-[#e0e0e0]">記事一覧</h2>
 
       <!-- Label Filter -->
       <div v-if="allLabels.length > 0" class="mb-6">
         <div class="flex flex-wrap gap-2">
           <button
             :class="[
-              'px-4 py-2 text-sm font-medium rounded-full transition-colors',
+              'px-4 py-2 text-sm font-medium transition-colors',
               selectedLabel === null
-                ? 'bg-blue-600 text-white'
-                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                ? 'bg-[#e0e0e0] text-[#111111]'
+                : 'bg-[#111111] text-[#e0e0e0] border-2 border-[#888888]'
             ]"
             @click="filterByLabel(null)"
           >
@@ -111,10 +111,10 @@ useSeoMeta({
             v-for="label in allLabels"
             :key="label"
             :class="[
-              'px-4 py-2 text-sm font-medium rounded-full transition-colors',
+              'px-4 py-2 text-sm font-medium transition-colors',
               selectedLabel === label
-                ? 'bg-blue-600 text-white'
-                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                ? 'bg-[#e0e0e0] text-[#111111]'
+                : 'bg-[#111111] text-[#e0e0e0] border-2 border-[#888888]'
             ]"
             @click="filterByLabel(label)"
           >
@@ -124,7 +124,7 @@ useSeoMeta({
       </div>
 
       <WikiPageList v-if="filteredPages.length > 0" :pages="filteredPages" />
-      <div v-else class="text-center text-gray-500 py-8">
+      <div v-else class="text-center text-[#e0e0e0]/50 py-8">
         ページがありません
       </div>
     </div>

--- a/wiki/nuxt.config.ts
+++ b/wiki/nuxt.config.ts
@@ -16,6 +16,13 @@ export default defineNuxtConfig({
   },
   app: {
     baseURL: process.env.NODE_ENV === 'production' ? '/mikinovation/' : '/',
+    head: {
+      link: [
+        { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+        { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' },
+        { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=DotGothic16&display=swap' },
+      ],
+    },
   },
   nitro: {
     prerender: {


### PR DESCRIPTION
## Summary
- Redesign the entire Wiki site with a retro game-style monochrome (black & white) theme
- Introduce DotGothic16 pixel font for a retro aesthetic
- Remove rounded corners and shadows, unify with solid border straight-line design

## Changes
- **nuxt.config.ts**: Load DotGothic16 from Google Fonts
- **main.css**: Add CSS custom properties (monochrome palette), prose overrides, scrollbar styling
- **Layouts**: Update Header/Footer/default.vue to dark background with gray borders
- **Components**: Unify PageCard, PageContent, RelatedArticles, ProsePre to monochrome theme
- **Pages**: Update text colors and button styles in wiki/index.vue and wiki/[slug].vue

## Test plan
- [ ] Start dev server with `cd wiki && npm run dev` and verify display
- [ ] Verify card and filter button display on Wiki index page
- [ ] Verify article body, code blocks, and Mermaid diagrams on detail pages
- [ ] Verify related articles section display
- [ ] Verify responsive layout at mobile width