### PR TITLE
feat(wiki): add /issue page with org-roam style graph view

### DIFF
--- a/wiki/.nuxtrc
+++ b/wiki/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@nuxt/test-utils="4.0.2"

--- a/wiki/app/components/graph/RoamGraph.client.vue
+++ b/wiki/app/components/graph/RoamGraph.client.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { VueFlow, type Edge, type Node } from '@vue-flow/core'
+import { Background } from '@vue-flow/background'
+import { Controls } from '@vue-flow/controls'
+import RoamNode from './RoamNode.vue'
+import type { RoamGraph } from '~/types/graph'
+
+const props = defineProps<{ graph: RoamGraph }>()
+
+const positioned = computed(() => computeForceLayout(props.graph))
+
+const nodes = computed<Node[]>(() =>
+  positioned.value.map(n => ({
+    id: n.id,
+    type: 'roam',
+    position: { x: n.x, y: n.y },
+    data: { title: n.title, tags: n.tags, status: n.status },
+  })),
+)
+
+const edges = computed<Edge[]>(() =>
+  props.graph.edges.map((e, i) => ({
+    id: `e-${i}`,
+    source: e.source,
+    target: e.target,
+    style: {
+      stroke: e.kind === 'parent' ? '#6a8' : '#666',
+      strokeWidth: 1,
+      strokeDasharray: e.kind === 'parent' ? '4 2' : undefined,
+    },
+  })),
+)
+
+const nodeTypes = { roam: RoamNode }
+</script>
+
+<template>
+  <div class="h-[80vh] border-2 border-[#888888] bg-[#0a0a0a]">
+    <VueFlow
+      :nodes="nodes"
+      :edges="edges"
+      :node-types="nodeTypes"
+      :nodes-draggable="true"
+      :nodes-connectable="false"
+      :elements-selectable="true"
+      fit-view-on-init
+    >
+      <Background pattern-color="#222" :gap="24" />
+      <Controls />
+    </VueFlow>
+  </div>
+</template>

--- a/wiki/app/components/graph/RoamNode.vue
+++ b/wiki/app/components/graph/RoamNode.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { Handle, Position } from '@vue-flow/core'
+
+defineProps<{
+  data: {
+    title: string
+    tags: string[]
+    status: 'open' | 'closed'
+  }
+}>()
+</script>
+
+<template>
+  <div
+    :class="[
+      'rounded border-2 px-3 py-2 max-w-[220px] min-w-[140px]',
+      data.status === 'closed'
+        ? 'border-[#555] bg-[#1a1a1a] text-[#888] line-through'
+        : 'border-[#888] bg-[#222222] text-[#e0e0e0]',
+    ]"
+  >
+    <div class="text-sm break-words">
+      {{ data.title }}
+    </div>
+    <div v-if="data.tags.length" class="mt-1 flex flex-wrap gap-1">
+      <span
+        v-for="t in data.tags"
+        :key="t"
+        class="text-[10px] px-1 border border-[#555] text-[#aaa]"
+      >
+        #{{ t }}
+      </span>
+    </div>
+    <Handle type="target" :position="Position.Left" class="!opacity-0" />
+    <Handle type="source" :position="Position.Right" class="!opacity-0" />
+  </div>
+</template>

--- a/wiki/app/components/layout/Header.vue
+++ b/wiki/app/components/layout/Header.vue
@@ -13,6 +13,9 @@
           <NuxtLink to="/" class="text-[#e0e0e0] hover:text-[#888888]">
             Home
           </NuxtLink>
+          <NuxtLink to="/issue" class="text-[#e0e0e0] hover:text-[#888888]">
+            Issue
+          </NuxtLink>
         </div>
       </div>
     </nav>

--- a/wiki/app/composables/useForceLayout.ts
+++ b/wiki/app/composables/useForceLayout.ts
@@ -1,0 +1,26 @@
+import {
+  forceCenter,
+  forceCollide,
+  forceLink,
+  forceManyBody,
+  forceSimulation,
+} from 'd3-force'
+import type { RoamGraph, RoamNode } from '~/types/graph'
+
+export type PositionedNode = RoamNode & { x: number, y: number }
+
+export function computeForceLayout(graph: RoamGraph, ticks = 300): PositionedNode[] {
+  const sNodes: PositionedNode[] = graph.nodes.map(n => ({ ...n, x: 0, y: 0 }))
+  const sEdges = graph.edges.map(e => ({ source: e.source, target: e.target }))
+
+  const sim = forceSimulation(sNodes as unknown as { x: number, y: number }[])
+    .force('charge', forceManyBody().strength(-220))
+    .force('center', forceCenter(0, 0))
+    .force('link', forceLink(sEdges).id((d: unknown) => (d as { id: string }).id).distance(110))
+    .force('collide', forceCollide(50))
+    .stop()
+
+  for (let i = 0; i < ticks; i++) sim.tick()
+
+  return sNodes
+}

--- a/wiki/app/pages/issue/index.vue
+++ b/wiki/app/pages/issue/index.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import type { RoamGraph } from '~/types/graph'
+
+const { data: graph } = await useFetch<RoamGraph>('/api/graph')
+
+useSeoMeta({ title: 'Issue Graph - mikinovation' })
+</script>
+
+<template>
+  <div class="container mx-auto px-4 py-8">
+    <h1 class="text-4xl font-bold text-[#e0e0e0] mb-2 tracking-wider">
+      &gt; Issue_Graph_
+    </h1>
+    <p class="text-sm text-[#888] mb-4">
+      編集は <code class="text-[#aaa]">wiki/data/issue.org</code> を直接編集してください。
+    </p>
+    <ClientOnly>
+      <GraphRoamGraph v-if="graph" :graph="graph" />
+      <template #fallback>
+        <div class="h-[80vh] border-2 border-[#888888] bg-[#0a0a0a] flex items-center justify-center text-[#666]">
+          loading...
+        </div>
+      </template>
+    </ClientOnly>
+  </div>
+</template>

--- a/wiki/app/types/graph.ts
+++ b/wiki/app/types/graph.ts
@@ -1,0 +1,22 @@
+export type RoamStatus = 'open' | 'closed'
+
+export type RoamNode = {
+  id: string
+  title: string
+  status: RoamStatus
+  tags: string[]
+  level: number
+}
+
+export type RoamEdgeKind = 'link' | 'parent'
+
+export type RoamEdge = {
+  source: string
+  target: string
+  kind: RoamEdgeKind
+}
+
+export type RoamGraph = {
+  nodes: RoamNode[]
+  edges: RoamEdge[]
+}

--- a/wiki/data/issue.org
+++ b/wiki/data/issue.org
@@ -1,0 +1,31 @@
+#+TITLE: Issue Tracker
+#+STARTUP: showall
+
+* TODO Nuxt のグラフページを作る :nuxt:wiki:
+:PROPERTIES:
+:ID: c1a3e5f2-1111-4111-8111-aaaaaaaaaaaa
+:END:
+
+vue-flow と d3-force を使い、issue.org をネットワーク可視化する。
+関連 [[id:b2d4f6a3-2222-4222-8222-bbbbbbbbbbbb][issue.org のスキーマを定義する]]。
+
+** TODO ノード詳細パネルの実装
+:PROPERTIES:
+:ID: d3e5f7b4-3333-4333-8333-cccccccccccc
+:END:
+
+クリックされたノードのタイトル/タグ/forward links/backlinks を UModal で表示する。
+
+* TODO issue.org のスキーマを定義する :spec:
+:PROPERTIES:
+:ID: b2d4f6a3-2222-4222-8222-bbbbbbbbbbbb
+:END:
+
+org-mode の見出しに =:ID:= プロパティを付け、本文中の =[[id:xxx]]= リンクをエッジとして扱う。
+
+* DONE 既存 wiki の整理 :wiki:
+:PROPERTIES:
+:ID: e4f6a8c5-4444-4444-8444-dddddddddddd
+:END:
+
+既存の content/wiki/*.md には触れず、別ページとして /graph を独立させる方針。

--- a/wiki/nuxt.config.ts
+++ b/wiki/nuxt.config.ts
@@ -10,7 +10,12 @@ export default defineNuxtConfig({
     '@nuxt/test-utils',
     '@nuxt/ui'
   ],
-  css: ['@/assets/css/main.css'],
+  css: [
+    '@/assets/css/main.css',
+    '@vue-flow/core/dist/style.css',
+    '@vue-flow/core/dist/theme-default.css',
+    '@vue-flow/controls/dist/style.css',
+  ],
   content: {
     experimental: { nativeSqlite: true }
   },
@@ -27,7 +32,7 @@ export default defineNuxtConfig({
   nitro: {
     prerender: {
       crawlLinks: true,
-      routes: ['/']
+      routes: ['/', '/issue', '/api/graph']
     }
   }
 })

--- a/wiki/package.json
+++ b/wiki/package.json
@@ -18,7 +18,11 @@
     "@nuxt/test-utils": "4.0.2",
     "@nuxt/ui": "4.5.1",
     "@unhead/vue": "2.1.12",
+    "@vue-flow/background": "1.3.2",
+    "@vue-flow/controls": "1.1.3",
+    "@vue-flow/core": "1.48.2",
     "better-sqlite3": "12.8.0",
+    "d3-force": "3.0.0",
     "eslint": "10.2.1",
     "mermaid": "11.14.0",
     "nuxt": "4.4.2",
@@ -29,6 +33,7 @@
   "packageManager": "pnpm@10.33.1+sha512.05ba3c1d5d1c18f68df06470d74055e62d41fc110a0c660db1b2dfb2785327f04cf0f68345d4609bc52089e7fa0343c31593b2f9594e2c5d5da426230acc9820",
   "devDependencies": {
     "@tailwindcss/typography": "0.5.19",
+    "@types/d3-force": "3.0.10",
     "@types/node": "24.12.2"
   }
 }

--- a/wiki/pnpm-lock.yaml
+++ b/wiki/pnpm-lock.yaml
@@ -29,9 +29,21 @@ importers:
       '@unhead/vue':
         specifier: 2.1.12
         version: 2.1.12(vue@3.5.30(typescript@5.9.3))
+      '@vue-flow/background':
+        specifier: 1.3.2
+        version: 1.3.2(@vue-flow/core@1.48.2(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+      '@vue-flow/controls':
+        specifier: 1.1.3
+        version: 1.1.3(@vue-flow/core@1.48.2(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+      '@vue-flow/core':
+        specifier: 1.48.2
+        version: 1.48.2(vue@3.5.30(typescript@5.9.3))
       better-sqlite3:
         specifier: 12.8.0
         version: 12.8.0
+      d3-force:
+        specifier: 3.0.0
+        version: 3.0.0
       eslint:
         specifier: 10.2.1
         version: 10.2.1(jiti@2.6.1)
@@ -54,6 +66,9 @@ importers:
       '@tailwindcss/typography':
         specifier: 0.5.19
         version: 0.5.19
+      '@types/d3-force':
+        specifier: 3.0.10
+        version: 3.0.10
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
@@ -2700,6 +2715,23 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
+  '@vue-flow/background@1.3.2':
+    resolution: {integrity: sha512-eJPhDcLj1wEo45bBoqTXw1uhl0yK2RaQGnEINqvvBsAFKh/camHJd5NPmOdS1w+M9lggc9igUewxaEd3iCQX2w==}
+    peerDependencies:
+      '@vue-flow/core': ^1.23.0
+      vue: ^3.3.0
+
+  '@vue-flow/controls@1.1.3':
+    resolution: {integrity: sha512-XCf+G+jCvaWURdFlZmOjifZGw3XMhN5hHlfMGkWh9xot+9nH9gdTZtn+ldIJKtarg3B21iyHU8JjKDhYcB6JMw==}
+    peerDependencies:
+      '@vue-flow/core': ^1.23.0
+      vue: ^3.3.0
+
+  '@vue-flow/core@1.48.2':
+    resolution: {integrity: sha512-raxhgKWE+G/mcEvXJjGFUDYW9rAI3GOtiHR3ZkNpwBWuIaCC1EYiBmKGwJOoNzVFgwO7COgErnK7i08i287AFA==}
+    peerDependencies:
+      vue: ^3.3.0
 
   '@vue-macros/common@3.1.1':
     resolution: {integrity: sha512-afW2DMjgCBVs33mWRlz7YsGHzoEEupnl0DK5ZTKsgziAlLh5syc5m+GM7eqeYrgiQpwMaVxa1fk73caCvPxyAw==}
@@ -9818,6 +9850,27 @@ snapshots:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+
+  '@vue-flow/background@1.3.2(@vue-flow/core@1.48.2(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@vue-flow/core': 1.48.2(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
+  '@vue-flow/controls@1.1.3(@vue-flow/core@1.48.2(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@vue-flow/core': 1.48.2(vue@3.5.30(typescript@5.9.3))
+      vue: 3.5.30(typescript@5.9.3)
+
+  '@vue-flow/core@1.48.2(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@vueuse/core': 10.11.1(vue@3.5.30(typescript@5.9.3))
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      vue: 3.5.30(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   '@vue-macros/common@3.1.1(vue@3.5.30(typescript@5.9.3))':
     dependencies:

--- a/wiki/server/api/graph.get.ts
+++ b/wiki/server/api/graph.get.ts
@@ -1,0 +1,9 @@
+import { promises as fs } from 'node:fs'
+import { resolve } from 'node:path'
+import { parseOrgRoam } from '~~/server/utils/parseOrgRoam'
+
+export default defineEventHandler(async () => {
+  const path = resolve(process.cwd(), 'data/issue.org')
+  const text = await fs.readFile(path, 'utf-8').catch(() => '')
+  return parseOrgRoam(text)
+})

--- a/wiki/server/utils/parseOrgRoam.ts
+++ b/wiki/server/utils/parseOrgRoam.ts
@@ -1,0 +1,102 @@
+import type { RoamEdge, RoamGraph, RoamNode, RoamStatus } from '~~/app/types/graph'
+
+const HEADING = /^(\*+)\s+(?:(TODO|NEXT|WAIT|HOLD|DONE|CANCELLED)\s+)?(.+?)(?:\s+(:[\w@:]+:))?\s*$/
+const ID_PROP = /^\s*:ID:\s+([\w-]+)\s*$/i
+const PROPS_BEGIN = /^\s*:PROPERTIES:\s*$/
+const PROPS_END = /^\s*:END:\s*$/
+const ID_LINK = /\[\[id:([\w-]+)\](?:\[[^\]]*\])?\]/g
+const SRC_BEGIN = /^\s*#\+begin_src\b/i
+const SRC_END = /^\s*#\+end_src\s*$/i
+
+const closedStatuses = new Set(['DONE', 'CANCELLED'])
+
+type Pending = {
+  node: RoamNode
+  bodyStart: number
+}
+
+export function parseOrgRoam(text: string): RoamGraph {
+  const lines = text.split(/\r?\n/)
+  const nodes: RoamNode[] = []
+  const edges: RoamEdge[] = []
+  const parents: { id: string, level: number }[] = []
+
+  let pending: Pending | null = null
+  let inProps = false
+  let inSrc = false
+
+  const flush = (endLine: number) => {
+    if (!pending || !pending.node.id) {
+      pending = null
+      return
+    }
+    const body = lines.slice(pending.bodyStart, endLine).join('\n')
+    const sanitized = body.replace(/#\+begin_src[\s\S]*?#\+end_src/gi, '')
+    let m: RegExpExecArray | null
+    ID_LINK.lastIndex = 0
+    while ((m = ID_LINK.exec(sanitized))) {
+      edges.push({ source: pending.node.id, target: m[1]!, kind: 'link' })
+    }
+    while (parents.length && parents[parents.length - 1]!.level >= pending.node.level) {
+      parents.pop()
+    }
+    if (parents.length) {
+      edges.push({ source: parents[parents.length - 1]!.id, target: pending.node.id, kind: 'parent' })
+    }
+    nodes.push(pending.node)
+    parents.push({ id: pending.node.id, level: pending.node.level })
+    pending = null
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i]!
+
+    if (inSrc) {
+      if (SRC_END.test(ln)) inSrc = false
+      continue
+    }
+    if (SRC_BEGIN.test(ln)) {
+      inSrc = true
+      continue
+    }
+
+    const h = HEADING.exec(ln)
+    if (h) {
+      flush(i)
+      const level = h[1]!.length
+      const kw = h[2]
+      const status: RoamStatus = kw && closedStatuses.has(kw) ? 'closed' : 'open'
+      const title = h[3]!.trim()
+      const tags = h[4] ? h[4].split(':').filter(Boolean) : []
+      pending = {
+        node: { id: '', title, status, tags, level },
+        bodyStart: i + 1,
+      }
+      inProps = false
+      continue
+    }
+
+    if (!pending) continue
+
+    if (PROPS_BEGIN.test(ln)) {
+      inProps = true
+      continue
+    }
+    if (inProps) {
+      if (PROPS_END.test(ln)) {
+        inProps = false
+        pending.bodyStart = i + 1
+        continue
+      }
+      const idm = ID_PROP.exec(ln)
+      if (idm) pending.node.id = idm[1]!
+    }
+  }
+  flush(lines.length)
+
+  const ids = new Set(nodes.map(n => n.id))
+  return {
+    nodes,
+    edges: edges.filter(e => ids.has(e.source) && ids.has(e.target)),
+  }
+}


### PR DESCRIPTION
## Summary
- Add /issue page that visualizes wiki/data/issue.org as a network using @vue-flow/core + d3-force
- Lightweight regex-based parser extracts headings with :ID: properties and [[id:UUID]] links (zero runtime dependencies)
- DONE/CANCELLED nodes are grayed out, tags shown as chips, heading hierarchy rendered as dashed parent edges
- Add /issue nav link in the header; add /issue and /api/graph to prerender routes

## Test plan
- [x] pnpm build succeeds (/issue and /api/graph are prerendered)
- [x] dev server returns HTTP 200 and /api/graph yields the expected JSON
- [x] Visually verify vue-flow rendering and d3-force layout in a browser
- [x] Verify useFetch('/api/graph') resolves under the production baseURL /mikinovation/