### PR TITLE
fix(wiki): remove duplicated baseURL in index redirect

### DIFF
--- a/wiki/app/pages/index.vue
+++ b/wiki/app/pages/index.vue
@@ -1,22 +1,5 @@
 <script setup lang="ts">
-const config = useRuntimeConfig()
-
-// production環境では /mikinovation/wiki にリダイレクト
-// development環境では /wiki にリダイレクト
-if (import.meta.client) {
-  const targetPath = config.app.baseURL === '/mikinovation/'
-    ? '/mikinovation/wiki'
-    : '/wiki'
-  await navigateTo(targetPath, { replace: true })
-}
-
-// サーバーサイドでもリダイレクト
-if (import.meta.server) {
-  const targetPath = config.app.baseURL === '/mikinovation/'
-    ? '/mikinovation/wiki'
-    : '/wiki'
-  await navigateTo(targetPath, { replace: true })
-}
+await navigateTo('/wiki', { replace: true })
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- `wiki/app/pages/index.vue` hardcoded the redirect target as `/mikinovation/wiki`. Since `navigateTo` automatically prepends `app.baseURL` (`/mikinovation/`), the generated `index.html` meta refresh pointed to `/mikinovation/mikinovation/wiki`, which 404'd on GitHub Pages.
- Pass only the route-relative path `/wiki` and drop the redundant `import.meta.client` / `import.meta.server` branches.

## Test plan
- [x] Ran `NUXT_APP_BASE_URL=/mikinovation/ pnpm run generate` and verified the meta refresh in `.output/public/index.html` points to `/mikinovation/wiki`.
- [x] After deploy, confirm visiting `https://mikinovation.github.io/mikinovation/` redirects to `/mikinovation/wiki/`.